### PR TITLE
Update Qt to 6.9.3

### DIFF
--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -36,24 +36,13 @@ inputs:
     description: "pass secrets.LKEB_CERT_CHAIN"
     required: true
 
-# Ubuntu 24.04 ships with libicu 74, see https://launchpad.net/ubuntu/+source/icu
-# but we some dependencies (qt 6.8) expect libicu 73, so we download is manually
 runs:
   using: "composite"
   steps:
     - name: Install conan & build configuration
       run: |
         if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-          sudo apt install -y ninja-build
-          sudo apt install -y libtbb-dev
-          sudo apt install -y wget
-
-          echo "Downloading libicu73..."
-          sudo wget -q https://github.com/unicode-org/icu/releases/download/release-73-2/icu4c-73_2-Ubuntu22.04-x64.tgz
-          sudo tar -xf icu4c-73_2-Ubuntu22.04-x64.tgz
-          sudo find ./icu/usr/local/lib/ -name "*.73*" -print0 | sudo xargs -0 cp -r -t /usr/lib/x86_64-linux-gnu/
-          sudo rm -rf ./icu/
-          sudo rm -rf icu4c-73_2-Ubuntu22.04-x64.tgz
+          sudo apt install -y ninja-build libtbb-dev wget
         fi
 
         if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -95,7 +84,7 @@ runs:
         CONAN_LKEB_ARTIFACTORY: lkeb-artifactory
 
     - name: Get compatibility logic
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: ManiVaultStudio/github-actions
         ref: compatibility

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -42,7 +42,7 @@ runs:
     - name: Install conan & build configuration
       run: |
         if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-          sudo apt install -y ninja-build libtbb-dev wget
+          sudo apt install -y ninja-build libtbb-dev libicu-dev wget
         fi
 
         if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -63,6 +63,7 @@ runs:
         
         pip install conan~=1.66.0
         pip install gitpython
+        pip install packaging
         pip install -v git+ssh://git@github.com/ManiVaultStudio/rulessupport.git@master
 
         export CONAN_CMAKE_PROGRAM=`which cmake`

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -42,7 +42,7 @@ runs:
     - name: Install conan & build configuration
       run: |
         if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-          sudo apt install -y ninja-build libtbb-dev libicu-dev wget
+          sudo apt install -y ninja-build libicu-dev libicu libicu-dev wget
         fi
 
         if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -42,7 +42,7 @@ runs:
     - name: Install conan & build configuration
       run: |
         if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-          sudo apt install -y ninja-build libicu-dev libicu libicu-dev wget
+          sudo apt install -y ninja-build libtbb-dev libicu-dev libicu74 wget
         fi
 
         if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -36,6 +36,8 @@ inputs:
     description: "pass secrets.LKEB_CERT_CHAIN"
     required: true
 
+# Ubuntu 24.04 ships with libicu 74, see https://launchpad.net/ubuntu/+source/icu
+# but we some dependencies expect libicu 73, so we download manually
 runs:
   using: "composite"
   steps:
@@ -43,6 +45,13 @@ runs:
       run: |
         if [[ "$OSTYPE" == "linux-gnu"* ]]; then
           sudo apt install -y ninja-build libtbb-dev libicu-dev libicu74 wget
+
+          echo "Downloading libicu73..."
+          sudo wget -q https://github.com/unicode-org/icu/releases/download/release-73-2/icu4c-73_2-Ubuntu22.04-x64.tgz
+          sudo tar -xf icu4c-73_2-Ubuntu22.04-x64.tgz
+          sudo find ./icu/usr/local/lib/ -name "*.73*" -print0 | sudo xargs -0 cp -r -t /usr/lib/x86_64-linux-gnu/
+          sudo rm -rf ./icu/
+          sudo rm -rf icu4c-73_2-Ubuntu22.04-x64.tgz
         fi
 
         if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/conan_windows_build/action.yml
+++ b/conan_windows_build/action.yml
@@ -142,7 +142,7 @@ runs:
 
     - name: Checkout the source
       if: ${{ inputs.sentry-upload }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: ManiVaultStudio/github-actions
         ref: refs/heads/upload_pdbs

--- a/conan_windows_build/action.yml
+++ b/conan_windows_build/action.yml
@@ -49,6 +49,7 @@ runs:
       run: |
         pip install conan~=1.66.0
         pip install gitpython
+        pip install packaging
         pip install git+ssh://git@github.com/ManiVaultStudio/rulessupport.git@master
 
         REM Fish the package name from the conanfile.py

--- a/matrix_setup/action.yml
+++ b/matrix_setup/action.yml
@@ -5,11 +5,9 @@ inputs:
     description: | 
       "A list of matrix ids to be used. Choose from
 
-       - windows_2019 
        - windows_2022 
        - linux_gcc11 
        - linux_gcc13 
-       - macos_code14 [x86]
        - macos_code15 [arm]
        - macos_code16 [arm]
        
@@ -26,7 +24,7 @@ runs:
   using: "composite"
   steps:
   - name: Get common matrix  
-    uses: actions/checkout@v4
+    uses: actions/checkout@v6
     with:
       repository: ManiVaultStudio/github-actions
       ref: main


### PR DESCRIPTION
Use [Qt 6.9.3](https://wiki.qt.io/Qt_6.9_Release) and update some actions:
- We now need to install the `packaging` pip package due to the updated Qt version